### PR TITLE
corrections des erreurs dans les fichiers cts work

### DIFF
--- a/data/pos2006/pos200604/Boillot_teiHeader.xml
+++ b/data/pos2006/pos200604/Boillot_teiHeader.xml
@@ -4,7 +4,7 @@
 <teiHeader>
     <fileDesc>
         <titleStmt>
-            <title type="main">Histoire d’un organe de diffusion de la culture allemande en France. La <i>Revue_germanique<i> (1905-1939)</title>      
+            <title type="main">Histoire d’un organe de diffusion de la culture allemande en France. La <i>Revue_germanique</i> (1905-1939)</title>      
             <author ref="https://www.idref.fr/114274304">Cécile Boillot</author>
         </titleStmt>
         <editionStmt>

--- a/data/pos2006/pos200604/Boillot_teiHeader.xml
+++ b/data/pos2006/pos200604/Boillot_teiHeader.xml
@@ -27,7 +27,7 @@
                     <title>Positions des thèses soutenues par les élèves de la promotion de 2006 pour obtenir le diplôme d’archiviste paléographe, <pubPlace>Paris</pubPlace>,<publisher>École nationale des chartes</publisher><biblScope unit="annee">2006</biblScope></title>
             <relatedItem type="these">
                 <bibl>
-                     <title ref="http://www.sudoc.fr/">Histoire d’un organe de diffusion de la culture allemande en France. La <i>Revue_germanique<i> (1905-1939)</title> 
+                     <title ref="http://www.sudoc.fr/">Histoire d’un organe de diffusion de la culture allemande en France. La <i>Revue_germanique</i> (1905-1939)</title> 
                 </bibl>
             </relatedItem>
             </bibl>     

--- a/data/pos2006/pos200604/__cts__.xml
+++ b/data/pos2006/pos200604/__cts__.xml
@@ -3,7 +3,7 @@
     xmlns:dct="http://purl.org/dc/terms/" xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     groupUrn="urn:cts:freLit:pos2006" projid="freLit:pos200604"
     urn="urn:cts:freLit:pos2006.pos200604" xml:lang="fre"> 
-    <ti:title xml:lang="fre">Histoire d’un organe de diffusion de la culture allemande en France. La <i>Revue_germanique<i> (1905-1939)</ti:title>
+    <ti:title xml:lang="fre">Histoire d’un organe de diffusion de la culture allemande en France. La <i>Revue_germanique</i> (1905-1939)</ti:title>
     <cpt:structured-metadata>
         <dc:publisher xml:lang="fre">École nationale des Chartes</dc:publisher>
         <dc:date rdf:datatype="xsd:gYear">2006</dc:date>

--- a/data/pos2006/pos200611/Chermette_teiHeader.xml
+++ b/data/pos2006/pos200611/Chermette_teiHeader.xml
@@ -4,7 +4,7 @@
 <teiHeader>
     <fileDesc>
         <titleStmt>
-            <title type="main">Images de presse. Production et usages de la photographie dans un quotidien d’information : <i>Le_Journal<i> (1929-1935)</title>      
+            <title type="main">Images de presse. Production et usages de la photographie dans un quotidien d’information : <i>Le_Journal</i> (1929-1935)</title>      
             <author ref="https://www.idref.fr/">Myriam Chermette</author>
         </titleStmt>
         <editionStmt>

--- a/data/pos2006/pos200611/Chermette_teiHeader.xml
+++ b/data/pos2006/pos200611/Chermette_teiHeader.xml
@@ -27,7 +27,7 @@
                     <title>Positions des thèses soutenues par les élèves de la promotion de 2006 pour obtenir le diplôme d’archiviste paléographe, <pubPlace>Paris</pubPlace>,<publisher>École nationale des chartes</publisher><biblScope unit="annee">2006</biblScope></title>
             <relatedItem type="these">
                 <bibl>
-                     <title ref="http://www.sudoc.fr/">Images de presse. Production et usages de la photographie dans un quotidien d’information : <i>Le_Journal<i> (1929-1935)</title> 
+                     <title ref="http://www.sudoc.fr/">Images de presse. Production et usages de la photographie dans un quotidien d’information : <i>Le_Journal</i> (1929-1935)</title> 
                 </bibl>
             </relatedItem>
             </bibl>     

--- a/data/pos2006/pos200611/__cts__.xml
+++ b/data/pos2006/pos200611/__cts__.xml
@@ -3,7 +3,7 @@
     xmlns:dct="http://purl.org/dc/terms/" xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     groupUrn="urn:cts:freLit:pos2006" projid="freLit:pos200611"
     urn="urn:cts:freLit:pos2006.pos200611" xml:lang="fre"> 
-    <ti:title xml:lang="fre">Images de presse. Production et usages de la photographie dans un quotidien d’information : <i>Le_Journal<i> (1929-1935)</ti:title>
+    <ti:title xml:lang="fre">Images de presse. Production et usages de la photographie dans un quotidien d’information : <i>Le_Journal</i> (1929-1935)</ti:title>
     <cpt:structured-metadata>
         <dc:publisher xml:lang="fre">École nationale des Chartes</dc:publisher>
         <dc:date rdf:datatype="xsd:gYear">2006</dc:date>

--- a/data/pos2010/pos201021/Richard_teiHeader.xml
+++ b/data/pos2010/pos201021/Richard_teiHeader.xml
@@ -27,7 +27,7 @@
                     <title>Positions des thèses soutenues par les élèves de la promotion de 2010 pour obtenir le diplôme d’archiviste paléographe, <pubPlace>Paris</pubPlace>,<publisher>École nationale des chartes</publisher><biblScope unit="annee">2010</biblScope></title>
             <relatedItem type="these">
                 <bibl>
-                     <title ref="http://www.sudoc.fr/143110624">La chambre_du_roi à Versailles ou l’espace de la majesté Intérieurs, institutions et cérémonial au </abbr>xvii<sup>e</sup></num> siècle.</title> 
+                     <title ref="http://www.sudoc.fr/143110624">La chambre_du_roi à Versailles ou l’espace de la majesté Intérieurs, institutions et cérémonial au <abbr>xvii<sup>e</sup></abbr> siècle.</title> 
                 </bibl>
             </relatedItem>
             </bibl>     

--- a/data/pos2010/pos201021/Richard_teiHeader.xml
+++ b/data/pos2010/pos201021/Richard_teiHeader.xml
@@ -27,7 +27,7 @@
                     <title>Positions des thèses soutenues par les élèves de la promotion de 2010 pour obtenir le diplôme d’archiviste paléographe, <pubPlace>Paris</pubPlace>,<publisher>École nationale des chartes</publisher><biblScope unit="annee">2010</biblScope></title>
             <relatedItem type="these">
                 <bibl>
-                     <title ref="http://www.sudoc.fr/143110624">La chambre_du_roi à Versailles ou l’espace de la majesté Intérieurs, institutions et cérémonial au <abbr>xvii<sup>e</sup></num> siècle.</title> 
+                     <title ref="http://www.sudoc.fr/143110624">La chambre_du_roi à Versailles ou l’espace de la majesté Intérieurs, institutions et cérémonial au </abbr>xvii<sup>e</sup></num> siècle.</title> 
                 </bibl>
             </relatedItem>
             </bibl>     

--- a/data/pos2010/pos201021/Richard_teiHeader.xml
+++ b/data/pos2010/pos201021/Richard_teiHeader.xml
@@ -4,7 +4,7 @@
 <teiHeader>
     <fileDesc>
         <titleStmt>
-            <title type="main">La chambre_du_roi à Versailles ou l’espace de la majesté Intérieurs, institutions et cérémonial au <abbr>xvii<sup>e</sup></num> siècle.</title>      
+            <title type="main">La chambre_du_roi à Versailles ou l’espace de la majesté Intérieurs, institutions et cérémonial au <abbr>xvii<sup>e</sup></abbr> siècle.</title>      
             <author ref="https://www.idref.fr/143110756">Vivien Richard</author>
         </titleStmt>
         <editionStmt>

--- a/data/pos2010/pos201021/__cts__.xml
+++ b/data/pos2010/pos201021/__cts__.xml
@@ -3,7 +3,7 @@
     xmlns:dct="http://purl.org/dc/terms/" xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     groupUrn="urn:cts:freLit:pos2010" projid="freLit:pos201021"
     urn="urn:cts:freLit:pos2010.pos201021" xml:lang="fre"> 
-    <ti:title xml:lang="fre">La chambre_du_roi à Versailles ou l’espace de la majesté Intérieurs, institutions et cérémonial au </abbr>xvii<sup>e</sup></num> siècle.</ti:title>
+    <ti:title xml:lang="fre">La chambre_du_roi à Versailles ou l’espace de la majesté Intérieurs, institutions et cérémonial au <abbr>xvii<sup>e</sup></abbr> siècle.</ti:title>
     <cpt:structured-metadata>
         <dc:publisher xml:lang="fre">École nationale des Chartes</dc:publisher>
         <dc:date rdf:datatype="xsd:gYear">2010</dc:date>

--- a/data/pos2010/pos201021/__cts__.xml
+++ b/data/pos2010/pos201021/__cts__.xml
@@ -3,7 +3,7 @@
     xmlns:dct="http://purl.org/dc/terms/" xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     groupUrn="urn:cts:freLit:pos2010" projid="freLit:pos201021"
     urn="urn:cts:freLit:pos2010.pos201021" xml:lang="fre"> 
-    <ti:title xml:lang="fre">La chambre_du_roi à Versailles ou l’espace de la majesté Intérieurs, institutions et cérémonial au <abbr>xvii<sup>e</sup></num> siècle.</ti:title>
+    <ti:title xml:lang="fre">La chambre_du_roi à Versailles ou l’espace de la majesté Intérieurs, institutions et cérémonial au </abbr>xvii<sup>e</sup></num> siècle.</ti:title>
     <cpt:structured-metadata>
         <dc:publisher xml:lang="fre">École nationale des Chartes</dc:publisher>
         <dc:date rdf:datatype="xsd:gYear">2010</dc:date>


### PR DESCRIPTION
#26 

Corrections d'erreurs dans les fichiers cts work et teiHeader créés automatiquement (balises i et abbr non fermées).
Résultat des tests Travis : 
data/pos2006/pos200604/__cts__.xml
data/pos2006/pos200611/__cts__.xml 
data/pos2010/pos201021/__cts__.xml